### PR TITLE
docs(readme): remove snyk badge

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,6 @@
 # pino-filter
 [![npm version](https://img.shields.io/npm/v/pino-filter)](https://www.npmjs.com/package/pino-filter)
 [![Build Status](https://img.shields.io/github/workflow/status/pinojs/pino-filter/CI)](https://github.com/pinojs/pino-filter/actions)
-[![Known Vulnerabilities](https://snyk.io/test/github/pinojs/pino-filter/badge.svg)](https://snyk.io/test/github/pinojs/pino-filter)
 [![Coverage Status](https://coveralls.io/repos/github/pinojs/pino-filter/badge.svg?branch=master)](https://coveralls.io/github/pinojs/pino-filter?branch=master)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 


### PR DESCRIPTION
Removes the Snyk badge from the readme, as the `actions/dependency-review-action` does the same thing as Snyk and will replace it.